### PR TITLE
pytorch 0.3 correction

### DIFF
--- a/meta_optimizer.py
+++ b/meta_optimizer.py
@@ -137,7 +137,8 @@ class FastMetaOptimizer(nn.Module):
         self.f, self.i = self(inputs)
 
         # Meta update itself
-        flat_params = self.f * flat_params - self.i * Variable(flat_grads)
+        flat_params = torch.t(self.f) * flat_params - torch.t(self.i) * Variable(flat_grads)
+        flat_params = flat_params.view(-1)
 
         self.meta_model.set_flat_params(flat_params)
 


### PR DESCRIPTION
The current version of the code produce a NxN matrix of weight instead of a N vector of weight (N the number of weight of the model to optimize).
I modify a bit the code to produce the correct vector.